### PR TITLE
Tidy up CSV destination

### DIFF
--- a/lib/etl/control/destination.rb
+++ b/lib/etl/control/destination.rb
@@ -94,16 +94,7 @@ module ETL #:nodoc:
       
       # Get the order of elements from the source order
       def order_from_source
-        order = []
-        control.sources.first.definition.each do |item|
-          case item
-          when Hash
-            order << item[:name]
-          else
-            order << item
-          end
-        end
-        order
+        control.sources.first.order
       end
       
       # Return true if the row is allowed. The row will not be allowed if the

--- a/lib/etl/control/destination/csv_destination.rb
+++ b/lib/etl/control/destination/csv_destination.rb
@@ -48,10 +48,13 @@ module ETL #:nodoc:
         @enclose = true & configuration[:enclose]
         @unique = configuration[:unique] ? configuration[:unique] + scd_required_fields : configuration[:unique]
         @unique.uniq! unless @unique.nil?
-        @order = mapping[:order] ? mapping[:order] + scd_required_fields : order_from_source
         @write_header = configuration[:write_header]
+        @order = mapping[:order] + scd_required_fields if mapping[:order]
         @order.uniq! unless @order.nil?
-        raise ControlError, "Order required in mapping" unless @order
+      end
+
+      def order
+        @order ||= order_from_source
       end
       
       # Close the destination. This will flush the buffer and close the underlying stream or connection.

--- a/lib/etl/control/source.rb
+++ b/lib/etl/control/source.rb
@@ -125,6 +125,19 @@ module ETL #:nodoc:
         Engine.read_locally
       end
       
+      # Get the order of fields that this source will present to the pipeline
+      def order
+        order = []
+        definition.each do |item|
+          case item
+          when Hash
+            order << item[:name]
+          else
+            order << item
+          end
+        end
+        order
+      end
     end
   end
 end

--- a/lib/etl/control/source/file_source.rb
+++ b/lib/etl/control/source/file_source.rb
@@ -53,6 +53,10 @@ module ETL #:nodoc:
         end
       end
       
+      def order
+        @parser.fields.collect {|field| field.name}
+      end
+
       private
       # Copy source data to a local directory structure
       def copy_sources


### PR DESCRIPTION
A couple of changes:
- a little change allows CSV Destinations to write a header line at the top of the output CSV.
- little refactor pushes Destination#order_from_source nearer where it belongs in the source implementations themselves. Then for FileSource, the field order actually comes from the Parser.
- then on top of those changes I've added a bit that makes specifying output fields optional for a csv_destination: it can find the order from the source.

End result is that a simple pipeline that transforms from one CSV into another CSV can be specified with a .ctl like this (and without specifying all the fields):

```
require File.dirname(__FILE__) + "/ifapps_encode_processor"

source :in, {
    :file => "t102.csv",
    :parser => :csv,
    :skip_lines => 1,
}

# ... transform and filter stuff in here

destination :out, {
    :type => :csv,
    :file => "t102-decoded.csv",
    :write_header => true,
}
```

Sorry there's no tests for these changes: I haven't got a DB set up to run the tests yet (we're doing NoSQL stuff over here).
