### PR TITLE
Fix for #95 - source :join does not prepend 'join' in SQL query

### DIFF
--- a/lib/etl/control/source/database_source.rb
+++ b/lib/etl/control/source/database_source.rb
@@ -172,7 +172,7 @@ module ETL #:nodoc:
       def query
         return @query if @query
         q = "SELECT #{select} FROM #{@table}"
-        q << " #{join}" if join
+        q << " JOIN #{join}" if join
         
         conditions = []
         if new_records_only


### PR DESCRIPTION
Prepends JOIN keyword to database source query.
