### PR TITLE
CDATA issue with SAX parser

### DIFF
--- a/lib/etl/parser/sax_parser.rb
+++ b/lib/etl/parser/sax_parser.rb
@@ -67,8 +67,8 @@ module ETL #:nodoc:
         @value = nil
         @proc = Proc.new(&block)
       end
-      def cdata(text)    
-        @value << text
+      def cdata(text)
+        characters(text)
       end
       def characters(text)
         text = text.strip

--- a/test/data/sax.xml
+++ b/test/data/sax.xml
@@ -2,12 +2,12 @@
 
 <people>
   <person age="24">
-    <first_name>Bob</first_name>
+    <first_name><![CDATA[Bob]]></first_name>
     <last_name>Smith</last_name>
     <social_security_number>123456789</social_security_number>
   </person>
   <person age="31">
-    <first_name>John</first_name>
+    <first_name><![CDATA[John]]></first_name>
     <last_name>Doe</last_name>
     <social_security_number>222114545</social_security_number>
   </person>


### PR DESCRIPTION
Hi,

CDATA parsing with SAX parser raises an error. I have updated the code to have the same behavior between ETL::Parser::Listener#characters and ETL::Parser::Listener#cdata.

Regards,

Julien
