### PR TITLE
	Added XLSX support, optional row validation, added SQLite insert_update_db

### DIFF
--- a/lib/etl/control/destination/insert_update_database_destination.rb
+++ b/lib/etl/control/destination/insert_update_database_destination.rb
@@ -82,6 +82,8 @@ module ETL #:nodoc:
                 res.free
               when "ActiveRecord::ConnectionAdapters::Mysql2Adapter"
                 res.each { none = false }
+              when "ActiveRecord::ConnectionAdapters::SQLite3Adapter"
+                res.each { none = false }
               else raise "Unsupported adapter #{conn.class} for this destination"
             end
 

--- a/lib/etl/engine.rb
+++ b/lib/etl/engine.rb
@@ -309,12 +309,13 @@ module ETL #:nodoc:
       control = ETL::Control::Control.resolve(control)
       say_on_own_line "Processing control #{control.file}"
       
-      ETL::Engine.job = ETL::Execution::Job.create!(
-        :control_file => control.file, 
-        :status => 'executing',
-        :batch_id => ETL::Engine.batch ? ETL::Engine.batch.id : nil
-      )
-      
+      ETL::Engine.job = ETL::Execution::Job.new.tap do |job|
+        job.control_file = control.file
+        job.status = 'executing'
+        job.batch_id = ETL::Engine.batch ? ETL::Engine.batch.id : nil
+        job.save!
+      end
+
       execute_dependencies(control)
       
       start_time = Time.now

--- a/lib/etl/parser/csv_parser.rb
+++ b/lib/etl/parser/csv_parser.rb
@@ -10,6 +10,8 @@ module ETL #:nodoc:
         configure
       end
       
+      attr_reader :validate_rows
+
       def get_fields_names(file)
         File.open(file) do |input|
           fields = CSV.parse(input.readline, options).first
@@ -43,7 +45,7 @@ module ETL #:nodoc:
             end
             line += 1
             row = {}
-            validate_row(raw_row, line, file)
+            validate_row(raw_row, line, file) if self.validate_rows
             raw_row.each_with_index do |value, index|
               f = fields[index]
               row[f.name] = value
@@ -70,6 +72,12 @@ module ETL #:nodoc:
       end
       
       def configure
+        @validate_rows = if source.configuration.has_key?(:validate_rows)
+                           source.configuration[:validate_rows]
+                         else
+                           true
+                         end
+        
         source.definition.each do |options|
           case options
           when Symbol


### PR DESCRIPTION
1. Added xslx support through Roo gem.
   - [Roo](https://github.com/Empact/roo) appears to be more fully featured than [Spreadsheet](https://github.com/zdavatz/spreadsheet), and it supports XLSX files whereas the latter does not.  Other than that it seems to be a drop-in replacement.
2. Made row validation optional on ExcelParser.
   - I was running into issues where it's no big deal for my script to be smart enough to skip invalid rows but the whole ETL job would barf because one row was missing a field.  putting `:validate => false` in the parser options will skip row-level validation.
3. Added SQLite3 to the `insert_update_database` destination.  It works.
4. The changes to `engine.rb` are for ActiveRecord 3.2.x, which will not allow mass-assignment unless expressly enabled on the model.  This change seemed easier than modifying the model class `ETL::Execution::Job` since I didn't know what might break if I change that class around.
