### PR TITLE
ActiveRecord::Base#verify_active_connections! is obsolete

### DIFF
--- a/lib/etl/engine.rb
+++ b/lib/etl/engine.rb
@@ -502,7 +502,6 @@ module ETL #:nodoc:
 #         say "Avg #{klass}: #{Engine.rows_read/t} rows/sec"
 #       end
 
-      ActiveRecord::Base.verify_active_connections!
       ETL::Engine.job.completed_at = Time.now
       ETL::Engine.job.status = (errors.length > 0 ? 'completed with errors' : 'completed')
       ETL::Engine.job.save!


### PR DESCRIPTION
This method has been removed from Rails in rails/rails@9d1f1b1ea9e5d637984fda4f276db77ffd1dbdcb
