### PR TITLE
password should not in command

### DIFF
--- a/lib/etl/control/source/mysql_streamer.rb
+++ b/lib/etl/control/source/mysql_streamer.rb
@@ -49,8 +49,9 @@ class MySqlStreamer
     database = mandatory_option!(config, 'database')
     password = config['password'] # this one can omitted in some cases
 
-    mysql_command = """mysql --quick -h #{host} -u #{username} -e \"#{@query.gsub("\n","")}\" -D #{database} --password=#{password} -B"""
+    mysql_command = """mysql --quick -h #{host} -u #{username} -e \"#{@query.gsub("\n","")}\" -D #{database} -B"""
     Open3.popen3(mysql_command) do |stdin, out, err, external|
+      stdin.puts password
       until (line = out.gets).nil? do
         line = line.gsub("\n","")
         if keys.nil?


### PR DESCRIPTION
Avoid the warning of "Using a password on the command line interface can be insecure" for mysql 5.6+.
